### PR TITLE
pybats.readarray: check file consistency before allocating memory

### DIFF
--- a/tests/test_pybats.py
+++ b/tests/test_pybats.py
@@ -86,6 +86,18 @@ class TestIdlFile(unittest.TestCase):
         self.assertEqual(self.knownMhdZlim, mhd['z'].max())
         self.assertEqual(self.knownMhdZlim*-1, mhd['z'].min())
 
+    def testReadAsciiAsBin(self):
+        """Read an ASCII file as a binary"""
+        try:
+            data = pb.IdlFile('data/pybats_test/mag_grid_ascii.out',
+                              format='bin', header=None, keep_case=True)
+        except EOFError as e:
+            msg = str(e)
+        else:
+            self.fail('Should have raised EOFError')
+        self.assertEqual(msg, 'File is shorter than expected data')
+
+
 class TestRim(unittest.TestCase):
 
     def testReadZip(self):


### PR DESCRIPTION
This checks for the root cause of the MemoryError in reading a maggrid file without actually trying to allocate all the memory. It's a bit grottier than I'd like but does work.

Incidentally, the explicit dtype cast is necessary to get itemsize (and it works if the thing being cast is already a dtype.) I have no idea how the code which is currently there actually works properly; I can't get `numpy.int32.itemsize` to give a number.