### PR TITLE
Update coords tests

### DIFF
--- a/tests/test_ctrans.py
+++ b/tests/test_ctrans.py
@@ -118,7 +118,6 @@ class CTransClassTests(unittest.TestCase):
         self.CTrans2000.calcMagTransforms()
         self.assertIn('DipoleTilt_rad', self.CTrans2000)
 
-    @unittest.expectedFailure
     def test_GMST_versions_different(self):
         """GMST versions should not be identical"""
         ct2k_82 = ctrans.CTrans(self.t2k, pnmodel='IAU82')
@@ -129,7 +128,7 @@ class CTransClassTests(unittest.TestCase):
         # IAU00
         ct2k_00.gmst()
         exp2 = ct2k_00['GMST']
-        numpy.testing.assert_approx_equal(exp1, exp2, significant=10)
+        self.assertNotAlmostEqual(exp1, exp2, places=10)
 
     def test_GMST_versions_similar(self):
         """GMST versions should all be roughly similar (not a regression test)"""

--- a/tests/test_ctrans.py
+++ b/tests/test_ctrans.py
@@ -11,6 +11,8 @@ import unittest
 
 import numpy
 from scipy.constants import arcsec
+
+import spacepy_testing
 from spacepy import ctrans
 import spacepy.time
 

--- a/tests/test_igrf.py
+++ b/tests/test_igrf.py
@@ -10,6 +10,8 @@ import unittest
 import warnings
 
 import numpy
+
+import spacepy_testing
 from spacepy import igrf
 
 __all__ = ['IgrfClassTests']


### PR DESCRIPTION
Some quick changes to the tests in the new coordinates code:

- Import spacepy_testing at the top of the new test_igrf and test_ctrans, so that the version of spacepy in the build directory is imported rather than the installed version
- Convert an "expected failure" to a positive test. The problem with "expected failure" is that if there is an exception raised, that counts as "failure". Since this looked like single value comparison, there was an easy standard library test to use.
