### PR TITLE
Change default handling; consolidate tests

### DIFF
--- a/spacepy/coordinates.py
+++ b/spacepy/coordinates.py
@@ -62,18 +62,17 @@ Setting options for coordinate transformation
 The backend for coordinate transformations can be provided at instantiation
 of a Coords object use a keyword argument. However, for convenience and
 flexibility the options can be set at the module level. Configurable options
-include the backend used (IRBEM or SpacePy), the reference ellipsoid (only
-configurable for the SpacePy backend), and whether warnings are raised by
-this module on instantiation without explicitly setting the backend. The
+include the backend used (IRBEM or SpacePy) and the reference ellipsoid (only
+configurable for the SpacePy backend). A warning will be raised if the backend
+is not set (either through the defaults or the keyword argument). The
 final configurable option (_itol_) is the maximum separation, in seconds,
 for which the coordinate transformations will not be recalculated. To force
 all transformations to use an exact transform for the time, set itol to zero.
 Values between 10s and 60s are recommended for speed while also preserving
 accuracy, though different applications will require different accuracies.
 For example, assuming this module has been imported as _spc_, to set the 
-SpacePy backend as the default, to set _itol_ to 5 seconds, and to disable
-warnings:
-`spc.DEFAULTS.set_values(use_irbem=False, itol=5, show_warning=False)`
+SpacePy backend as the default, to set _itol_ to 5 seconds:
+`spc.DEFAULTS.set_values(use_irbem=False, itol=5)`
 
 Authors: Steven Morley and Josef Koller
 Institution: Los ALamos National Laboratory
@@ -117,7 +116,7 @@ class __Defaults(object):
     '''Configuration factory for coordinates module default settings
     '''
     def __init__(self):
-        self._fac = namedtuple('values', 'use_irbem, show_warning, ellipsoid, itol')
+        self._fac = namedtuple('values', 'use_irbem, ellipsoid, itol')
         self.set_values()
 
     def __repr__(self):
@@ -125,7 +124,7 @@ class __Defaults(object):
         b1 = full.index('(')
         return 'DEFAULTS{}'.format(full[b1:])
 
-    def set_values(self, use_irbem=None, show_warning=True, ellipsoid=ctrans.WGS84, itol=30):
+    def set_values(self, use_irbem=None, ellipsoid=ctrans.WGS84, itol=30):
         '''Set options for coordinate transforms
 
         Parameters
@@ -133,9 +132,6 @@ class __Defaults(object):
         use_irbem : bool
             If True, use IRBEM as coordinate transform backend. If False, use SpacePy's
             implementations. Default is to use IRBEM (and warn) but this will change.
-        show_warning : bool
-            Set to False to squelch warnings. If True a warning will be displayed when
-            instantiating a Coords object without explicitly setting the backend.
         ellipsoid : spacepy.ctrans.Ellipsoid
             A reference ellipsoid to use for the Earth radius definition and for geodetic
             coordinate conversion. SpacePy defaults to the WGS84 ellipsoid and the semi-major
@@ -143,7 +139,6 @@ class __Defaults(object):
             an Earth radius using 6371.2 km.
         '''
         self.values = self._fac(use_irbem=use_irbem,
-                                show_warning=show_warning,
                                 ellipsoid=ellipsoid,
                                 itol=itol)
 
@@ -228,10 +223,9 @@ class Coords(object):
             use_irbem = DEFAULTS.values.use_irbem
         if use_irbem is None:
             use_irbem = True
-            if DEFAULTS.values.show_warning:
-                warnings.warn('No coordinate backend specified; using IRBEM.'
-                              ' This default will change in the future.',
-                              DeprecationWarning)
+            warnings.warn('No coordinate backend specified; using IRBEM.'
+                          ' This default will change in the future.',
+                          DeprecationWarning)
         if use_irbem:
             from . import irbempy as op
         self.use_irbem = use_irbem

--- a/tests/test_coordinates.py
+++ b/tests/test_coordinates.py
@@ -389,7 +389,7 @@ class coordsTestIrbem(unittest.TestCase):
     def setUp(self):
         try:
             with warnings.catch_warnings():
-                warnings.filterwarnings('ignore', message=r'Use of IRBEM to perform',
+                warnings.filterwarnings('ignore', message=r'No coordinate backend',
                                         category=DeprecationWarning,
                                         module=r'spacepy.coordinates$')
                 self.cvals = spc.Coords([[1, 2, 4], [1, 2, 2]], 'GEO', 'car', use_irbem=True)
@@ -410,7 +410,7 @@ class coordsTestIrbem(unittest.TestCase):
     def test_append(self):
         """Test append functionality"""
         with warnings.catch_warnings():
-            warnings.filterwarnings('ignore', message=r'Use of IRBEM to perform',
+            warnings.filterwarnings('ignore', message=r'No coordinate backend',
                                     category=DeprecationWarning,
                                     module=r'spacepy.coordinates$')
             c2 = spc.Coords([[6, 7, 8], [9, 10, 11]], 'GEO', 'car', use_irbem=True)
@@ -421,7 +421,7 @@ class coordsTestIrbem(unittest.TestCase):
     def test_slice(self):
         """Test slice functionality"""
         with warnings.catch_warnings():
-            warnings.filterwarnings('ignore', message=r'Use of IRBEM to perform',
+            warnings.filterwarnings('ignore', message=r'No coordinate backend',
                                     category=DeprecationWarning,
                                     module=r'spacepy.coordinates$')
             expected = spc.Coords([1, 2, 4], 'GEO', 'car', use_irbem=True)
@@ -431,7 +431,7 @@ class coordsTestIrbem(unittest.TestCase):
         """Test slice functionality with ticks attribute"""
         self.cvals.ticks = Ticktock(['2002-02-02T12:00:00', '2002-02-02T12:00:00'], 'ISO')
         with warnings.catch_warnings():
-            warnings.filterwarnings('ignore', message=r'Use of IRBEM to perform',
+            warnings.filterwarnings('ignore', message=r'No coordinate backend',
                                     category=DeprecationWarning,
                                     module=r'spacepy.coordinates$')
             expected = spc.Coords([1, 2, 4], 'GEO', 'car', use_irbem=True)
@@ -483,7 +483,11 @@ class coordsTestIrbem(unittest.TestCase):
                                           unit='Mm', frame='itrs',
                                           obstime=['2001-02-03T04:00:00', '2005-06-07T08:00:00'])
 
-        coords = spc.Coords.from_skycoord(sc)
+        with warnings.catch_warnings():
+            warnings.filterwarnings('ignore', message=r'No coordinate backend',
+                                    category=DeprecationWarning,
+                                    module=r'spacepy.coordinates$')
+            coords = spc.Coords.from_skycoord(sc)
 
         # Check that the data was loaded correctly
         sc_data = sc.cartesian.xyz.to('m').value.T
@@ -499,7 +503,11 @@ class coordsTestIrbem(unittest.TestCase):
                                           obstime=['2001-02-03T04:00:00', '2005-06-07T08:00:00'])
 
         # Convert to a frame other than GEO before calling from_skycoord()
-        coords = spc.Coords.from_skycoord(sc.gcrs)
+        with warnings.catch_warnings():
+            warnings.filterwarnings('ignore', message=r'No coordinate backend',
+                                    category=DeprecationWarning,
+                                    module=r'spacepy.coordinates$')
+            coords = spc.Coords.from_skycoord(sc.gcrs)
 
         # Check that the data was loaded correctly
         sc_data = sc.cartesian.xyz.to('m').value.T
@@ -512,7 +520,7 @@ class coordsTestIrbem(unittest.TestCase):
         """Roundtrip should yield input as answer"""
         self.cvals.ticks = Ticktock(['2002-02-02T12:00:00', '2002-02-02T12:00:00'], 'ISO')
         with warnings.catch_warnings():
-            warnings.filterwarnings('ignore', message=r'Use of IRBEM to perform',
+            warnings.filterwarnings('ignore', message=r'No coordinate backend',
                                     category=DeprecationWarning,
                                     module=r'spacepy.coordinates$')
             expected = spc.Coords(self.cvals.data, 'GEO', 'car', use_irbem=True)
@@ -524,7 +532,7 @@ class coordsTestIrbem(unittest.TestCase):
     def test_GEO_GSE(self):
         """Regression test for IRBEM call"""
         with warnings.catch_warnings():
-            warnings.filterwarnings('ignore', message=r'Use of IRBEM to perform',
+            warnings.filterwarnings('ignore', message=r'No coordinate backend',
                                     category=DeprecationWarning,
                                     module=r'spacepy.coordinates$')
             test_cc = spc.Coords([1, 2, 3], 'GEO', 'car',
@@ -538,7 +546,7 @@ class coordsTestIrbem(unittest.TestCase):
     def test_GEO_is_SPH(self):
         """GEO in spherical is SPH"""
         with warnings.catch_warnings():
-            warnings.filterwarnings('ignore', message=r'Use of IRBEM to perform',
+            warnings.filterwarnings('ignore', message=r'No coordinate backend',
                                     category=DeprecationWarning,
                                     module=r'spacepy.coordinates$')
             test_gsp = spc.Coords([4, 45, 90], 'GEO', 'sph',
@@ -560,7 +568,7 @@ class coordsTestIrbem(unittest.TestCase):
         pos_km = np.array([2367.83158, -5981.75882, -4263.24591])
         pos_re = pos_km/6371.2
         with warnings.catch_warnings():
-            warnings.filterwarnings('ignore', message=r'Use of IRBEM to perform',
+            warnings.filterwarnings('ignore', message=r'No coordinate backend',
                                     category=DeprecationWarning,
                                     module=r'spacepy.coordinates$')
             cc_km = spc.Coords(pos_km, 'GEI', 'car', ticks=tt, units=['km', 'km', 'km'])
@@ -578,7 +586,7 @@ class coordsTestIrbem(unittest.TestCase):
         tt = Ticktock(2459218.5, 'JD')
         pos = np.array([2367.83158, -5981.75882, -4263.24591])
         with warnings.catch_warnings():
-            warnings.filterwarnings('ignore', message=r'Use of IRBEM to perform',
+            warnings.filterwarnings('ignore', message=r'No coordinate backend',
                                     category=DeprecationWarning,
                                     module=r'spacepy.coordinates$')
             cc_km = spc.Coords(pos, 'GEI', 'car', ticks=tt, units=['km', 'km', 'km'])
@@ -603,7 +611,7 @@ class coordsTestIrbem(unittest.TestCase):
         tt = Ticktock(2459218.5, 'JD')
         pos = np.array([2367.83158, -5981.75882, -4263.24591])
         with warnings.catch_warnings():
-            warnings.filterwarnings('ignore', message=r'Use of IRBEM to perform',
+            warnings.filterwarnings('ignore', message=r'No coordinate backend',
                                     category=DeprecationWarning,
                                     module=r'spacepy.coordinates$')
             self.assertRaises(ValueError, spc.Coords, pos, 'GDZ', 'car',
@@ -619,7 +627,7 @@ class coordsTestIrbem(unittest.TestCase):
         """Compare outputs on GSE Cartesian to SM spherical conversion"""
         tt = Ticktock([2459218.5]*2, 'JD')
         with warnings.catch_warnings():
-            warnings.filterwarnings('ignore', message=r'Use of IRBEM to perform',
+            warnings.filterwarnings('ignore', message=r'No coordinate backend',
                                     category=DeprecationWarning,
                                     module=r'spacepy.coordinates$')
             irb = spc.Coords(self.cvals.data, 'GSE', 'car', ticks=tt, use_irbem=True)
@@ -636,7 +644,7 @@ class coordsTestIrbem(unittest.TestCase):
         """Compare outputs on GSE Cartesian to SM spherical conversion"""
         tt = Ticktock([2459218.5]*2, 'JD')
         with warnings.catch_warnings():
-            warnings.filterwarnings('ignore', message=r'Use of IRBEM to perform',
+            warnings.filterwarnings('ignore', message=r'No coordinate backend',
                                     category=DeprecationWarning,
                                     module=r'spacepy.coordinates$')
             irb = spc.Coords(self.cvals.data, 'SM', 'car', ticks=tt, use_irbem=True)
@@ -652,7 +660,7 @@ class coordsTestIrbem(unittest.TestCase):
     def test_units_respected(self):
         """Units should be preserved on all conversions except to/from GDZ"""
         with warnings.catch_warnings():
-            warnings.filterwarnings('ignore', message=r'Use of IRBEM to perform',
+            warnings.filterwarnings('ignore', message=r'No coordinate backend',
                                     category=DeprecationWarning,
                                     module=r'spacepy.coordinates$')
             cc_gdz_r = spc.Coords([3, 45, 45], 'GDZ', 'sph',

--- a/tests/test_coordinates.py
+++ b/tests/test_coordinates.py
@@ -388,11 +388,7 @@ class coordsTest(unittest.TestCase):
 class coordsTestIrbem(unittest.TestCase):
     def setUp(self):
         try:
-            with warnings.catch_warnings():
-                warnings.filterwarnings('ignore', message=r'No coordinate backend',
-                                        category=DeprecationWarning,
-                                        module=r'spacepy.coordinates$')
-                self.cvals = spc.Coords([[1, 2, 4], [1, 2, 2]], 'GEO', 'car', use_irbem=True)
+            self.cvals = spc.Coords([[1, 2, 4], [1, 2, 2]], 'GEO', 'car', use_irbem=True)
         except ImportError:
             pass  # tests will fail, but won't bring down the entire suite
 
@@ -409,32 +405,20 @@ class coordsTestIrbem(unittest.TestCase):
 
     def test_append(self):
         """Test append functionality"""
-        with warnings.catch_warnings():
-            warnings.filterwarnings('ignore', message=r'No coordinate backend',
-                                    category=DeprecationWarning,
-                                    module=r'spacepy.coordinates$')
-            c2 = spc.Coords([[6, 7, 8], [9, 10, 11]], 'GEO', 'car', use_irbem=True)
+        c2 = spc.Coords([[6, 7, 8], [9, 10, 11]], 'GEO', 'car', use_irbem=True)
         actual = self.cvals.append(c2)
         expected = [[1, 2, 4], [1, 2, 2], [6, 7, 8], [9, 10, 11]]
         np.testing.assert_equal(expected, actual.data.tolist())
 
     def test_slice(self):
         """Test slice functionality"""
-        with warnings.catch_warnings():
-            warnings.filterwarnings('ignore', message=r'No coordinate backend',
-                                    category=DeprecationWarning,
-                                    module=r'spacepy.coordinates$')
-            expected = spc.Coords([1, 2, 4], 'GEO', 'car', use_irbem=True)
+        expected = spc.Coords([1, 2, 4], 'GEO', 'car', use_irbem=True)
         np.testing.assert_equal(expected.data, self.cvals[0].data)
 
     def test_slice_with_ticks(self):
         """Test slice functionality with ticks attribute"""
         self.cvals.ticks = Ticktock(['2002-02-02T12:00:00', '2002-02-02T12:00:00'], 'ISO')
-        with warnings.catch_warnings():
-            warnings.filterwarnings('ignore', message=r'No coordinate backend',
-                                    category=DeprecationWarning,
-                                    module=r'spacepy.coordinates$')
-            expected = spc.Coords([1, 2, 4], 'GEO', 'car', use_irbem=True)
+        expected = spc.Coords([1, 2, 4], 'GEO', 'car', use_irbem=True)
         np.testing.assert_equal(expected.data, self.cvals[0].data)
 
     @unittest.skipUnless(HAVE_ASTROPY, 'requires Astropy')
@@ -519,11 +503,7 @@ class coordsTestIrbem(unittest.TestCase):
     def test_roundtrip_GEO_GEI(self):
         """Roundtrip should yield input as answer"""
         self.cvals.ticks = Ticktock(['2002-02-02T12:00:00', '2002-02-02T12:00:00'], 'ISO')
-        with warnings.catch_warnings():
-            warnings.filterwarnings('ignore', message=r'No coordinate backend',
-                                    category=DeprecationWarning,
-                                    module=r'spacepy.coordinates$')
-            expected = spc.Coords(self.cvals.data, 'GEO', 'car', use_irbem=True)
+        expected = spc.Coords(self.cvals.data, 'GEO', 'car', use_irbem=True)
         stage1 = self.cvals.convert('GEI', 'car')
         got = stage1.convert('GEO', 'car')
         np.testing.assert_allclose(got.data, expected.data)
@@ -531,13 +511,9 @@ class coordsTestIrbem(unittest.TestCase):
 
     def test_GEO_GSE(self):
         """Regression test for IRBEM call"""
-        with warnings.catch_warnings():
-            warnings.filterwarnings('ignore', message=r'No coordinate backend',
-                                    category=DeprecationWarning,
-                                    module=r'spacepy.coordinates$')
-            test_cc = spc.Coords([1, 2, 3], 'GEO', 'car',
-                                 ticks=Ticktock([2459213.5], 'JD'),
-                                 use_irbem=True)
+        test_cc = spc.Coords([1, 2, 3], 'GEO', 'car',
+                             ticks=Ticktock([2459213.5], 'JD'),
+                             use_irbem=True)
         expected = [[-2.118751061419987, -1.8297009536234092, 2.4825253744601286]]
         got = test_cc.convert('GSE', 'car')
         np.testing.assert_allclose(got.data, expected)
@@ -545,16 +521,12 @@ class coordsTestIrbem(unittest.TestCase):
 
     def test_GEO_is_SPH(self):
         """GEO in spherical is SPH"""
-        with warnings.catch_warnings():
-            warnings.filterwarnings('ignore', message=r'No coordinate backend',
-                                    category=DeprecationWarning,
-                                    module=r'spacepy.coordinates$')
-            test_gsp = spc.Coords([4, 45, 90], 'GEO', 'sph',
-                                  ticks=Ticktock([2459213.5], 'JD'),
-                                  use_irbem=True)
-            test_ssp = spc.Coords([4, 45, 90], 'SPH', 'sph',
-                                  ticks=Ticktock([2459213.5], 'JD'),
-                                  use_irbem=True)
+        test_gsp = spc.Coords([4, 45, 90], 'GEO', 'sph',
+                              ticks=Ticktock([2459213.5], 'JD'),
+                              use_irbem=True)
+        test_ssp = spc.Coords([4, 45, 90], 'SPH', 'sph',
+                              ticks=Ticktock([2459213.5], 'JD'),
+                              use_irbem=True)
         got_gsp = test_ssp.convert('GEO', 'sph')
         got_car1 = test_gsp.convert('GEO', 'car')
         np.testing.assert_allclose(got_gsp.data, test_ssp.data)
@@ -610,12 +582,8 @@ class coordsTestIrbem(unittest.TestCase):
         """Geodetic coordinates shouldn't be expressed in Cartesian"""
         tt = Ticktock(2459218.5, 'JD')
         pos = np.array([2367.83158, -5981.75882, -4263.24591])
-        with warnings.catch_warnings():
-            warnings.filterwarnings('ignore', message=r'No coordinate backend',
-                                    category=DeprecationWarning,
-                                    module=r'spacepy.coordinates$')
-            self.assertRaises(ValueError, spc.Coords, pos, 'GDZ', 'car',
-                              ticks=tt, use_irbem=True)
+        self.assertRaises(ValueError, spc.Coords, pos, 'GDZ', 'car',
+                          ticks=tt, use_irbem=True)
 
     def test_GEI_is_TOD(self):
         """IRBEM inertial isn't labelled, show it's TOD, i.e. GEO Z is TOD Z"""
@@ -626,12 +594,8 @@ class coordsTestIrbem(unittest.TestCase):
     def test_GSE_to_SMsph_vs_spacepy(self):
         """Compare outputs on GSE Cartesian to SM spherical conversion"""
         tt = Ticktock([2459218.5]*2, 'JD')
-        with warnings.catch_warnings():
-            warnings.filterwarnings('ignore', message=r'No coordinate backend',
-                                    category=DeprecationWarning,
-                                    module=r'spacepy.coordinates$')
-            irb = spc.Coords(self.cvals.data, 'GSE', 'car', ticks=tt, use_irbem=True)
-            non_irb = spc.Coords(self.cvals.data, 'GSE', 'car', ticks=tt, use_irbem=False)
+        irb = spc.Coords(self.cvals.data, 'GSE', 'car', ticks=tt, use_irbem=True)
+        non_irb = spc.Coords(self.cvals.data, 'GSE', 'car', ticks=tt, use_irbem=False)
         irb_got = irb.convert('SM', 'sph')
         nonirb_got = non_irb.convert('SM', 'sph')
         # Test is approx. as IRBEM systems are relative to TOD not MOD
@@ -643,12 +607,8 @@ class coordsTestIrbem(unittest.TestCase):
     def test_SM_to_MAG_vs_spacepy(self):
         """Compare outputs on GSE Cartesian to SM spherical conversion"""
         tt = Ticktock([2459218.5]*2, 'JD')
-        with warnings.catch_warnings():
-            warnings.filterwarnings('ignore', message=r'No coordinate backend',
-                                    category=DeprecationWarning,
-                                    module=r'spacepy.coordinates$')
-            irb = spc.Coords(self.cvals.data, 'SM', 'car', ticks=tt, use_irbem=True)
-            non_irb = spc.Coords(self.cvals.data, 'SM', 'car', ticks=tt, use_irbem=False)
+        irb = spc.Coords(self.cvals.data, 'SM', 'car', ticks=tt, use_irbem=True)
+        non_irb = spc.Coords(self.cvals.data, 'SM', 'car', ticks=tt, use_irbem=False)
         irb_got = irb.convert('CDMAG', 'car')
         nonirb_got = non_irb.convert('CDMAG', 'car')
         # Test is approx. as IRBEM systems are relative to TOD not MOD
@@ -659,22 +619,18 @@ class coordsTestIrbem(unittest.TestCase):
 
     def test_units_respected(self):
         """Units should be preserved on all conversions except to/from GDZ"""
-        with warnings.catch_warnings():
-            warnings.filterwarnings('ignore', message=r'No coordinate backend',
-                                    category=DeprecationWarning,
-                                    module=r'spacepy.coordinates$')
-            cc_gdz_r = spc.Coords([3, 45, 45], 'GDZ', 'sph',
-                                  ticks=Ticktock('2008-01-01'),
-                                  use_irbem=True, units=['Re', 'deg', 'deg'])
-            cc_sph_r = spc.Coords([3, 45, 45], 'GEO', 'sph',
-                                  ticks=Ticktock('2008-01-01'),
-                                  use_irbem=True, units=['Re', 'deg', 'deg'])
-            cc_gdz_k = spc.Coords([3*ctrans.WGS84['A'], 45, 45], 'GDZ', 'sph',
-                                  ticks=Ticktock('2008-01-01'),
-                                  use_irbem=True, units=['km', 'deg', 'deg'])
-            cc_sph_k = spc.Coords([3*ctrans.WGS84['A'], 45, 45], 'GEO', 'sph',
-                                  ticks=Ticktock('2008-01-01'),
-                                  use_irbem=True, units=['km', 'deg', 'deg'])
+        cc_gdz_r = spc.Coords([3, 45, 45], 'GDZ', 'sph',
+                              ticks=Ticktock('2008-01-01'),
+                              use_irbem=True, units=['Re', 'deg', 'deg'])
+        cc_sph_r = spc.Coords([3, 45, 45], 'GEO', 'sph',
+                              ticks=Ticktock('2008-01-01'),
+                              use_irbem=True, units=['Re', 'deg', 'deg'])
+        cc_gdz_k = spc.Coords([3*ctrans.WGS84['A'], 45, 45], 'GDZ', 'sph',
+                              ticks=Ticktock('2008-01-01'),
+                              use_irbem=True, units=['km', 'deg', 'deg'])
+        cc_sph_k = spc.Coords([3*ctrans.WGS84['A'], 45, 45], 'GEO', 'sph',
+                              ticks=Ticktock('2008-01-01'),
+                              use_irbem=True, units=['km', 'deg', 'deg'])
         # Conversion from GDZ goes to Re
         got_gdz_r = cc_gdz_r.convert('GSE', 'car')
         got_gdz_k = cc_gdz_k.convert('GSE', 'car')


### PR DESCRIPTION
Contains two types of changes that just sort of ran into each other.

The first is to change how the default backend was handled. Now, if someone specifies a backend, regardless of whether it was as a kwarg or in the module defaults, there will be no warning. If it isn't specified, there will always be a warning. This means I also removed the show_warning option: if you don't want a warning by setting an option, just set an explicit backend!

In the following release, it's a one-line change (well, two lines if you count the warning message) to change to the ctrans backend, and then easy to rip out all the warning stuff after.

The second type of change is entirely in the last commit. It takes all the tests that are identical, or nearly identical, between irbem and ctrans and puts them into a single class to run against ctrans. Then a simple subclass runs the same ones against irbem. That way if we need to do any updates, we only need to update one.