### PR TITLE
Document coordinates new dependency on scipy

### DIFF
--- a/Doc/source/dependencies.rst
+++ b/Doc/source/dependencies.rst
@@ -70,6 +70,8 @@ and numerical functions build on top of NumPy.  It is highly
 recommended. The following modules may have limited functionality
 without SciPy:
 
+    * :mod:`~spacepy.coordinates`
+    * :mod:`~spacepy.ctrans`
     * :mod:`~spacepy.empiricals`
     * :mod:`~spacepy.seapy`
     * :mod:`~spacepy.toolbox`
@@ -139,7 +141,10 @@ compiler ``g77``, and the Portland Group PGI compiler.
 If :mod:`~spacepy.irbempy` is to be used, the Fortran compiler (and
 f2py) must be installed before SpacePy.
 
-:mod:`~spacepy.coordinates` requires :mod:`~spacepy.irbempy`.
+:mod:`~spacepy.coordinates` requires :mod:`~spacepy.irbempy` to use
+the IRBEM-based backend, but the new CTrans-based backend can be used
+without Fortran. See the :mod:`~spacepy.coordinates` documentation for
+the ``use_irbem`` option.
 
 .. _dependencies_astropy:
 
@@ -174,12 +179,21 @@ unaffected by that dependency.
      - :ref:`AstroPy <dependencies_astropy>`
    * - :mod:`~spacepy.coordinates`
      -
-     - :class:`~spacepy.coordinates.Coords` (except Windows binaries)
+     - :class:`~spacepy.coordinates.Coords` IRBEM backend (except Windows binaries)
+     -
+     -
+     -
+     -
+     - :mod:`Entire module <spacepy.coordinates>`
+     -
+   * - :mod:`~spacepy.ctrans`
      -
      -
      -
      -
      -
+     -
+     - :mod:`Entire module <spacepy.ctrans>`
      -
    * - :mod:`~spacepy.datamodel`
      - * :meth:`~spacepy.datamodel.SpaceData.toCDF`

--- a/Doc/source/dependencies.rst
+++ b/Doc/source/dependencies.rst
@@ -185,7 +185,8 @@ unaffected by that dependency.
      -
      -
      - :mod:`Entire module <spacepy.coordinates>`
-     -
+     - * :meth:`~spacepy.coordinates.Coords.from_skycoord`
+       * :meth:`~spacepy.coordinates.Coords.to_skycoord`
    * - :mod:`~spacepy.ctrans`
      -
      -

--- a/Doc/source/release_notes.rst
+++ b/Doc/source/release_notes.rst
@@ -54,6 +54,12 @@ Quaternion math functions have been removed from
 :mod:`~spacepy.toolbox`; they are available in
 :mod:`~spacepy.coordinates`. (Deprecated in 0.2.2.)
 
+Dependency requirements
+***********************
+Due to the new backend, scipy is now required for
+:mod:`~spacepy.coordinates` (even if using the old backend). 0.11
+remains the minimum version.
+
 Other changes
 *************
 :mod:`~spacepy.pycdf` now defaults to creating version 3 (not


### PR DESCRIPTION
The coordinates module has picked up a dependency on scipy with the new backend. This PR documents that in our discussion of dependencies and chart. The requirement to have AstroPy for converting coords instances to/from SkyCoords is also added to the dependency table.